### PR TITLE
Add metadescription and remove trailing slash on void elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,11 @@
 <html lang="ca">
 
 <head>
-  <meta charset="UTF-8" />
-  <link rel="icon" type="image/png" href="/hackato.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <link rel="icon" type="image/png" href="/hackato.png">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hackato - Servei de l'Ocupació</title>
+  <meta name="description" content="Pàgina de prova per a la Hackató del Saló de l'Ocupació">
 </head>
 
 <body>


### PR DESCRIPTION
- Added metadescription to have every core web vital scored as 100
- Removed trail slashes as it doesn't have any effect on void elements